### PR TITLE
molecule: postgresql_version required

### DIFF
--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -11,7 +11,10 @@
         state: present
 
   roles:
+
     - role: ome.postgresql
+      postgresql_version: "10"
+
     - role: ansible-role-postgresql-backup
       postgresql_backup_dir: /backup/postgresql
       postgresql_backup_filename_format: >-


### PR DESCRIPTION
This is required by the current `ome.postgresql` role